### PR TITLE
Switch Spring AI integration to local Ollama service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# OpenAI API Key
-# Get your API key from: https://platform.openai.com/
-OPENAI_API_KEY=your-openai-api-key-here
+# Optional: override the Ollama endpoint used by the application
+# Defaults to http://localhost:11434 when not set
+OLLAMA_BASE_URL=http://localhost:11434
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to the SpaceX AI project!
 
 - Java 17 or higher
 - Maven 3.8+
-- An OpenAI API key for testing
+- Local Ollama runtime (Docker Compose setup provided)
 
 ### Getting Started
 
@@ -18,20 +18,14 @@ Thank you for your interest in contributing to the SpaceX AI project!
    cd spring-ai-poc
    ```
 
-2. Set up your environment:
-   ```bash
-   cp .env.example .env
-   # Edit .env and add your OpenAI API key
-   ```
-
-3. Build the project:
+2. Build the project:
    ```bash
    mvn clean install
    ```
 
-4. Run the application:
+3. Run the application:
    ```bash
-   export OPENAI_API_KEY=your-api-key
+   # Ensure the Ollama service is running (docker-compose up ollama)
    mvn spring-boot:run
    ```
 
@@ -148,13 +142,13 @@ Configuration can be updated in `src/main/resources/application.yml`:
 ```yaml
 spring:
   ai:
-    openai:
-      api-key: ${OPENAI_API_KEY}
+    ollama:
+      base-url: ${OLLAMA_BASE_URL:http://localhost:11434}
       chat:
         options:
-          model: gpt-4o-mini
+          model: phi3:mini
           temperature: 0.7
-          max-tokens: 4096
+          num-predict: 1024
 ```
 
 ## Troubleshooting
@@ -178,9 +172,9 @@ If you encounter build issues:
 
 If the application fails to start:
 
-1. Check that the OpenAI API key is set:
+1. Check that the Ollama service is reachable:
    ```bash
-   echo $OPENAI_API_KEY
+   curl http://localhost:11434/api/version
    ```
 
 2. Verify the SpaceX API is accessible:

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -26,14 +26,7 @@ curl -X POST http://localhost:8080/api/ask \
 ```json
 {
   "question": "What was the latest SpaceX launch?",
-  "answer": "The latest SpaceX launch was...",
-  "metadata": {
-    "model": "claude-3-5-sonnet",
-    "usage": {
-      "inputTokens": 25,
-      "outputTokens": 150
-    }
-  }
+  "answer": "The latest SpaceX launch was..."
 }
 ```
 
@@ -309,31 +302,13 @@ All `/ask` endpoint responses follow this format:
 ```json
 {
   "question": "The original question",
-  "answer": "Claude's response based on SpaceX data",
-  "metadata": {
-    "model": "claude-3-5-sonnet",
-    "usage": {
-      "inputTokens": 25,
-      "outputTokens": 150
-    }
-  }
+  "answer": "The model's response based on SpaceX data"
 }
 ```
 
 ## Error Handling
 
 The API may return errors in these scenarios:
-
-### Missing API Key
-
-```json
-{
-  "timestamp": "2025-11-02T13:00:00.000+00:00",
-  "status": 500,
-  "error": "Internal Server Error",
-  "message": "API key not configured"
-}
-```
 
 ### Invalid Request
 
@@ -353,7 +328,7 @@ The API may return errors in these scenarios:
   "timestamp": "2025-11-02T13:00:00.000+00:00",
   "status": 503,
   "error": "Service Unavailable",
-  "message": "Unable to connect to Anthropic API"
+  "message": "Unable to connect to Ollama service"
 }
 ```
 
@@ -387,7 +362,7 @@ docker ps | grep spacex-ai
 
 ### Slow Responses
 
-Claude AI responses may take a few seconds. For better UX:
+Local model responses may take a few seconds, especially on the first request while the model loads into memory. For better UX:
 - Show a loading indicator
 - Set appropriate timeouts (30-60 seconds)
 - Implement retry logic for transient failures
@@ -395,6 +370,6 @@ Claude AI responses may take a few seconds. For better UX:
 ### Invalid Responses
 
 If responses don't make sense:
-- Verify your Anthropic API key is valid
+- Verify the Ollama service is healthy (`curl http://localhost:11434/api/version`)
 - Check the question is clear and specific
 - Review the SpaceX API data availability

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This project implements a Spring Boot 3.4 REST service that integrates Spring AI with Anthropic Claude to provide natural language querying capabilities for the public SpaceX API.
+This project implements a Spring Boot 3.4 REST service that integrates Spring AI with a locally hosted Ollama model (phi3:mini) to provide natural language querying capabilities for the public SpaceX API.
 
 ## What Was Built
 
@@ -21,10 +21,10 @@ This project implements a Spring Boot 3.4 REST service that integrates Spring AI
   - Launchpads (all, by ID)
 
 ### 3. AI Integration
-- **AnthropicConfiguration.java**: Configuration for Anthropic Claude API
-- Model: claude-3-5-sonnet
+- **ChatClientConfiguration.java**: ChatClient configuration wired to the Spring AI Ollama starter
+- Model: phi3:mini (runs locally via Ollama)
 - Temperature: 0.7
-- Max tokens: 4096
+- Max predictions: 1024 tokens
 
 ### 4. REST API
 - **SpaceXAiController.java**: Main REST controller
@@ -54,7 +54,7 @@ This project implements a Spring Boot 3.4 REST service that integrates Spring AI
 
 ### 9. Configuration
 - **application.yml**: Application configuration with:
-  - Anthropic API key configuration
+  - Ollama endpoint configuration (defaults to http://localhost:11434)
   - SpaceX API base URL
   - Server port (8080)
   - Actuator endpoints
@@ -62,10 +62,11 @@ This project implements a Spring Boot 3.4 REST service that integrates Spring AI
 
 ### 10. Deployment
 - **Dockerfile**: Multi-stage Docker build with Java 17
-- **docker-compose.yml**: Docker Compose with two services:
+- **docker-compose.yml**: Docker Compose with three services:
+  - `ollama`: Local LLM runtime hosting phi3:mini
   - `spacex-ai`: Main REST API service
   - `spacex-ai-mcp`: MCP tool server
-- Includes health checks and proper configuration
+- Includes health checks, automatic model download, and proper configuration
 
 ### 11. Developer Tools
 - **run.sh**: Convenience script to build and run the application
@@ -92,7 +93,7 @@ This project implements a Spring Boot 3.4 REST service that integrates Spring AI
 ## Key Features Implemented
 
 ✅ Spring Boot 3.4 REST service
-✅ Spring AI integration with Anthropic Claude
+✅ Spring AI integration with local Ollama model
 ✅ Full SpaceX API client implementation
 ✅ Natural language query endpoint (`/ask`)
 ✅ MCP tool server for AI agents
@@ -115,8 +116,7 @@ This project implements a Spring Boot 3.4 REST service that integrates Spring AI
 
 ### Quick Start
 ```bash
-# Set API key
-export ANTHROPIC_API_KEY=your-key
+# Ensure Ollama is running (docker-compose up ollama)
 
 # Build and run
 ./run.sh
@@ -142,16 +142,16 @@ docker-compose up
 
 ### Request Flow
 1. User sends natural language question to `/api/ask`
-2. Spring AI formats the request for Claude
-3. Claude processes the question
+2. Spring AI formats the request for the local Ollama model
+3. The model processes the question
 4. Response is returned as structured JSON
 5. User receives AI-powered answer
 
 ### SpaceX Data Flow
 1. Controller receives question
-2. Claude AI analyzes the question
+2. Local LLM analyzes the question
 3. Application can fetch relevant SpaceX data
-4. Claude synthesizes answer from available data
+4. LLM synthesizes answer from available data
 5. Response includes question, answer, and metadata
 
 ## Future Enhancements
@@ -175,22 +175,22 @@ Potential additions (not implemented in current version):
 ### Why Spring AI 1.0.3?
 - Stable GA release
 - Available in Maven Central (no network issues)
-- Reliable Anthropic integration
+- Includes first-class Ollama starter
 
-### Why Claude?
-- Excellent natural language understanding
-- High-quality responses
-- Good API documentation
-- Specified in requirements
+### Why Ollama + phi3:mini?
+- Runs entirely on local hardware
+- Lightweight (~2.2 GB) but capable small language model
+- Easy to orchestrate with Docker Compose
+- No external API keys required
 
 ### Why Blocking WebClient?
 - Simpler code for this use case
-- Adequate performance for AI use case (already async via Claude)
+- Adequate performance for AI use case (already async via Spring AI + Ollama)
 - Easier to understand and maintain
 
 ## Security Considerations
 
-- API key stored in environment variable (never in code)
+- Ollama endpoint configurable via environment variable
 - Docker container runs as non-root user
 - No sensitive data logged
 - HTTPS recommended for production deployment
@@ -198,7 +198,7 @@ Potential additions (not implemented in current version):
 
 ## Performance Notes
 
-- Average response time: 2-5 seconds (depends on Claude API)
+- Average response time: 2-5 seconds (depends on local hardware + Ollama model)
 - JAR startup time: ~10-15 seconds
 - Memory usage: ~300-500 MB typical
 - Container size: ~200 MB compressed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,45 @@
 version: '3.8'
 
 services:
+  ollama:
+    image: ollama/ollama:0.3.12
+    container_name: spacex-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+
+  ollama-init:
+    image: ollama/ollama:0.3.12
+    container_name: spacex-ollama-init
+    depends_on:
+      ollama:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c", "OLLAMA_HOST=http://ollama:11434 ollama pull phi3:mini"]
+    volumes:
+      - ollama-data:/root/.ollama
+    restart: "no"
+
   spacex-ai:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: spacex-ai
+    depends_on:
+      ollama:
+        condition: service_healthy
+      ollama-init:
+        condition: service_completed_successfully
     ports:
       - "8080:8080"
     environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - SPRING_PROFILES_ACTIVE=prod
     restart: unless-stopped
     healthcheck:
@@ -30,3 +60,6 @@ services:
     stdin_open: true
     tty: true
     restart: unless-stopped
+
+volumes:
+  ollama-data:

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <artifactId>spacex-ai</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>spacex-ai</name>
-    <description>Spring Boot REST service using Spring AI + OpenAI to query SpaceX API</description>
+    <description>Spring Boot REST service using Spring AI + Ollama to query SpaceX API</description>
 
     <properties>
         <java.version>17</java.version>
@@ -35,10 +35,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         
-        <!-- Spring AI OpenAI Starter (autoconfiguration + core) -->
+        <!-- Spring AI Ollama Starter (autoconfiguration + core) -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+            <artifactId>spring-ai-ollama-spring-boot-starter</artifactId>
             <version>${spring-ai.version}</version>
         </dependency>
         

--- a/run.sh
+++ b/run.sh
@@ -2,12 +2,16 @@
 
 # Startup script for SpaceX AI REST service
 
-# Check if API key is set
-if [ -z "$OPENAI_API_KEY" ]; then
-    echo "Error: OPENAI_API_KEY environment variable is not set"
-    echo "Please set it with: export OPENAI_API_KEY=your-api-key"
-    echo "Or create a .env file with your API key"
-    exit 1
+# Determine Ollama endpoint
+OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://localhost:11434}
+
+echo "Using Ollama endpoint: $OLLAMA_BASE_URL"
+if ! curl -sSf "$OLLAMA_BASE_URL/api/version" >/dev/null 2>&1; then
+    cat <<'EOF'
+Warning: could not reach the Ollama service. Make sure it is running.
+You can start it via Docker Compose:
+  docker-compose up ollama
+EOF
 fi
 
 # Check if jar exists

--- a/src/main/java/com/spacex/ai/config/ChatClientConfiguration.java
+++ b/src/main/java/com/spacex/ai/config/ChatClientConfiguration.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class AnthropicConfiguration {
+public class ChatClientConfiguration {
 
     @Bean
     public ChatClient chatClient(ChatClient.Builder builder) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,13 +2,13 @@ spring:
   application:
     name: spacex-ai
   ai:
-    openai:
-      api-key: ${OPENAI_API_KEY:your-api-key-here}
+    ollama:
+      base-url: ${OLLAMA_BASE_URL:http://localhost:11434}
       chat:
         options:
-          model: gpt-4o-mini
+          model: phi3:mini
           temperature: 0.7
-          max-tokens: 4096
+          num-predict: 1024
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- replace the Spring AI OpenAI starter with the Ollama starter and point configuration at the local phi3:mini model
- extend docker-compose with Ollama services, update helper scripts, and expose the new ChatClient configuration
- refresh documentation and examples to reflect the new local LLM workflow

## Testing
- mvn -q test *(fails: Maven Central returned 403 while resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_69085846bd308327a431187b5710b5b7